### PR TITLE
Bump PHP to min 8.3

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -11,20 +11,19 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        php:
-          - 8.1
-          - 8.2
+        php-version:
           - 8.3
+          - 8.4
         composer: 
           - 2  
-    name: Test - php:${{ matrix.php }}; composer:${{ matrix.composer }}
+    name: Test - php:${{ matrix.php-version }}; composer:${{ matrix.composer }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install PHP
         uses: shivammathur/setup-php@master
         with:
-          php-version: ${{ matrix.php }}
+          php-version: ${{ matrix.php-version }}
           extensions: curl, pdo_sqlite, json, mbstring, pcre
           coverage: none
           tools: composer:v${{ matrix.composer }}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Smarty plugin that adds DB resource type",
     "type": "library",
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "ext-pdo": "*",
         "smarty/smarty": "^5"
     },


### PR DESCRIPTION
Resolves #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP version requirements to support PHP 8.3 and 8.4 in the workflow and composer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->